### PR TITLE
Add an ascending sort to the longform after the user sort spec 

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,7 +5,7 @@ Metrics/AbcSize:
   Max: 24.74
 
 Metrics/CyclomaticComplexity:
-  Max: 7
+  Max: 9
 
 Metrics/MethodLength:
   Max: 34

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Changelog for acromine
 
+## 0.1.1
+
+* force an ascending sort on the longform after whatever the user has specified in order to account for differences in ruby runtimes
+
 ## 0.1.0
 
 * initial version supporting acronym to longform expansion

--- a/README.md
+++ b/README.md
@@ -62,13 +62,15 @@ hash:
     acro.longforms('HMM').variants(limit: 5)
 
 Variants will be sorted by descending frequency count then by ascending
-variant year.  These can be changed using the 'sort_spec' option. The
-spec is one or two two-character pairs joined by a comma.  The first
-character of the pair is what to sort - f for the frequency and y for
-the year.  The second character of the pair is how to sort - a for
-ascending and d for descending:
+variant year and finally by ascending long form.
 
-    acro.longforms('HMM').variants(sort_spec: 'fa,yd'
+This order can be changed using the 'sort_spec' option. The spec is one
+or two two-character pairs joined by a comma.  The first character of
+the pair is what to sort - f for the frequency and y for the year.  The
+second character of the pair is how to sort - a for ascending and d for
+descending:
+
+    acro.longforms('HMM').variants(sort_spec: 'fa,yd')
 
 A LongformVariant object has three getter methods:
 

--- a/acromine.gemspec
+++ b/acromine.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: acromine 0.1.0.20150721074443 ruby lib
+# stub: acromine 0.1.1.20150721081626 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "acromine"
-  s.version = "0.1.0.20150721074443"
+  s.version = "0.1.1.20150721081626"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 ---
 machine:
   ruby:
-    version: 2.2.0
+    version: 2.1.6
 test:
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/cucumber $CIRCLE_TEST_REPORTS/rspec

--- a/lib/acromine/core.rb
+++ b/lib/acromine/core.rb
@@ -78,7 +78,7 @@ class Acromine
   # @param sort_spec [String] how to sort on frequency and year
   # @api private
   def massage_data(json, limit: nil, sort_spec: 'fd,ya')
-    xforms = build_sort_xforms(sort_spec)
+    xforms = build_sort_xforms(sort_spec + ',la')
     sorted = json.sort_by do |e|
       xforms.map { |x| x.call(e) }
     end
@@ -120,6 +120,11 @@ class Acromine
                     ->(x) { x['since'] }
                   when 'd'
                     ->(x) { -x['since'] }
+                  end
+                when 'l'
+                  case how
+                  when 'a'
+                    ->(x) { x['lf'] }
                   end
                 end
     end

--- a/lib/acromine/version.rb
+++ b/lib/acromine/version.rb
@@ -1,5 +1,5 @@
 # a client for the Acromine REST service
 class Acromine
   # the version of the gem
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/lib/acromine/core_spec.rb
+++ b/spec/lib/acromine/core_spec.rb
@@ -288,14 +288,14 @@ RSpec.describe Acromine do
       )
       terms = lfs.map { |e| e['lf'] }
       expect(terms).to eq([
-        'tropical calcific pancreatitis',
         'tricresyl phosphate',
-        'tranylcypromine',
+        'tropical calcific pancreatitis',
         '3,5,6-trichloro-2-pyridinol',
+        'tranylcypromine',
         'tricalcium phosphate',
         'tumor control probability',
-        'toxin-coregulated pilus',
-        '2,4,6-trichlorophenol'
+        '2,4,6-trichlorophenol',
+        'toxin-coregulated pilus'
       ])
     end
 
@@ -305,12 +305,12 @@ RSpec.describe Acromine do
       )
       terms = lfs.map { |e| e['lf'] }
       expect(terms).to eq([
-        'toxin-coregulated pilus',
         '2,4,6-trichlorophenol',
+        'toxin-coregulated pilus',
         'tricalcium phosphate',
         'tumor control probability',
-        'tranylcypromine',
         '3,5,6-trichloro-2-pyridinol',
+        'tranylcypromine',
         'tricresyl phosphate',
         'tropical calcific pancreatitis'
       ])
@@ -339,8 +339,8 @@ RSpec.describe Acromine do
       )
       terms = lfs.map { |e| e['lf'] }
       expect(terms).to eq([
-        'tricalcium phosphate',
         'toxin-coregulated pilus',
+        'tricalcium phosphate',
         'tumor control probability',
         '2,4,6-trichlorophenol',
         'tranylcypromine',
@@ -357,8 +357,8 @@ RSpec.describe Acromine do
       )
       terms = lfs.map { |e| e['lf'] }
       expect(terms).to eq([
-        'tricalcium phosphate',
         'toxin-coregulated pilus',
+        'tricalcium phosphate',
         'tumor control probability'
       ])
     end
@@ -370,8 +370,8 @@ RSpec.describe Acromine do
       )
       terms = lfs.map { |e| e['lf'] }
       expect(terms).to eq([
-        'tricalcium phosphate',
         'toxin-coregulated pilus',
+        'tricalcium phosphate',
         'tumor control probability',
         '2,4,6-trichlorophenol',
         'tranylcypromine',


### PR DESCRIPTION
to ensure that we get consistent results regardless of the ruby runtime and environment
Version bump to 0.1.1
